### PR TITLE
Add 1.8.2 on aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   summary: Data validation and settings management using python type hinting
   description: |
     Data validation and settings management using python type hinting.
-    See documentation <{{ docs_url }}> for more details.
+    See documentation <{{ docs_url }}> for more details. 
   doc_url: {{ docs_url }}
   dev_url: {{ repo_url }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python
     - pip
     - cython  # [not win]
+    - setuptools
+    - wheel
   run:
     - python
     - dataclasses >=0.6  # [py37]
@@ -31,6 +33,10 @@ requirements:
 test:
   imports:
     - {{ name }}
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: {{ repo_url }}


### PR DESCRIPTION
Add pydantic 1.8.2 on aarch64. 
It's a dependency of thinc 8.0.13, see https://github.com/AnacondaRecipes/thinc-feedstock/pull/9#issuecomment-963205493