### PR TITLE
Rebuild for py310 & py311 support

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pydantic" %}
 {% set version = "1.8.2" %}
-{% set repo_url = "https://github.com/samuelcolvin/pydantic" %}
-{% set docs_url = "https://pydantic-docs.helpmanual.io" %}
+{% set repo_url = "https://github.com/pydantic/pydantic" %}
+{% set docs_url = "https://docs.pydantic.dev" %}
 
 package:
   name: {{ name }}
@@ -12,8 +12,8 @@ source:
   sha256: 26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
   skip: true  # [py<36]
 
 requirements:
@@ -22,12 +22,12 @@ requirements:
   host:
     - python
     - pip
-    - cython  # [not win]
+    - cython 0.29.32  # [not win]
     - setuptools
     - wheel
   run:
     - python
-    - dataclasses >=0.6  # [py37]
+    - dataclasses >=0.6  # [py<37]
     - typing-extensions >=3.7.4.3
 
 test:


### PR DESCRIPTION
We need Python 3.10 and 3.11 support for **v1.8.2** because of incorrect `pydantic` pinnings in the recipes of `thinc 8.0.15` and `spacy 3.3.1` (must be `pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0` but we haven't the upper bound), see https://github.com/AnacondaRecipes/medspacy_quickumls-feedstock/pull/1#issuecomment-1543672479.
Then I'll try to rebuild `thinc 8.0.15` and `spacy 3.3.1` with the correct pinning. 
It will unblock https://github.com/AnacondaRecipes/medspacy_quickumls-feedstock/pull/1 and https://github.com/AnacondaRecipes/pyrush-feedstock/pull/1