### PR TITLE
Update to v 1.10.8:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pydantic" %}
-{% set version = "1.10.2" %}
+{% set version = "1.10.8" %}
 {% set repo_url = "https://github.com/pydantic/pydantic" %}
-{% set docs_url = "https://pydantic-docs.helpmanual.io" %}
+{% set docs_url = "https://docs.pydantic.dev/latest/" %}
 
 package:
   name: {{ name }}
@@ -9,11 +9,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410
+  sha256: 1410275520dfa70effadf4c21811d755e7ef9bb1f1d077a21958153a92c8d9ca
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -vv
   skip: true  # [py<37]
 
 requirements:
@@ -21,15 +21,16 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - cython >=0.29.32
+    - cython 0.29.32
     - pip
     - setuptools
     - wheel
   run:
     - python
-    - typing-extensions >=4.1.0
+    - typing-extensions >=4.2.0
   run_constrained:
     - email-validator >=1.0.3
+    - python-dotenv >=0.10.4
 
 test:
   imports:
@@ -44,13 +45,11 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://github.com/{{ name }}/{{ name }}/blob/v{{ version }}/LICENSE
   summary: Data validation and settings management using python type hinting
   description: |
     Data validation and settings management using python type hinting.
     See documentation <{{ docs_url }}> for more details.
   doc_url: {{ docs_url }}
-  doc_source_url: https://github.com/pydantic/pydantic/tree/main/docs
   dev_url: {{ repo_url }}
 
 extra:


### PR DESCRIPTION
 - version increased and sha256 updated.
 - build script updated with --no-build-isolation flag.
 - host and run dependencies updated.
 - doc_url updated.
 - redundant info removed